### PR TITLE
Fixed scale for PNG image generation

### DIFF
--- a/classes/ApiHandler.php
+++ b/classes/ApiHandler.php
@@ -150,10 +150,10 @@ class ApiHandler {
 							default:
 							case 'jpg':
 							case 'jpeg':
-								imagejpeg($image, null, 80);
+								imagejpeg($image, null, 80); //imagejpeg quality scale 0-100. default 75
 								break;
 							case 'png':
-								imagepng($image, null, 80);
+								imagepng($image, null, 8); //imagepng quality scale is 0-9. default 6
 								break;
 							case 'gif':
 								imagegif($image, null);


### PR DESCRIPTION
Generation of PNG files became broken with d068c763a2571b259d6578f3b5015dfac1851a73. This fixes it so they generate again