### PR TITLE
Add docker as an runnable environment

### DIFF
--- a/.docker/config/app/cron/15min/archive.sh
+++ b/.docker/config/app/cron/15min/archive.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+cd /var/www/ && php TaskRunner.php Archive

--- a/.docker/config/app/cron/hourly/audit.sh
+++ b/.docker/config/app/cron/hourly/audit.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+cd /var/www/ && php TaskRunner.php Audit

--- a/.docker/config/app/cron/hourly/thumbnails.sh
+++ b/.docker/config/app/cron/hourly/thumbnails.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+cd /var/www/ && php TaskRunner.php Thumbnails

--- a/.docker/config/nginx/vhost.conf
+++ b/.docker/config/nginx/vhost.conf
@@ -1,0 +1,60 @@
+server {
+    listen 80;
+    server_name _;
+    root /var/www/www;
+    index index.php index.html;
+
+    location / {
+        try_files $uri /index.html$is_args$args;
+
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            #
+            # Custom headers and headers various browsers *should* be OK with but aren't
+            #
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            #
+            # Tell client that this pre-flight info is valid for 20 days
+            #
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain; charset=utf-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+        if ($request_method = 'POST') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+        }
+        if ($request_method = 'GET') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+        }
+    }
+
+    location /images {
+        root /var/www/images;
+        expires 30d;
+        access_log off;
+    }
+
+    location ~* \.(jpg|jpeg|gif|css|png|js|ico|html|eof|woff|ttf)$ {
+        if (-f $request_filename) {
+            expires 30d;
+            access_log off;
+        }
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass app:9000;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    error_log /var/log/nginx/sf4_error.log;
+    access_log /var/log/nginx/sf4_access.log;
+}

--- a/.docker/config/php/php.ini
+++ b/.docker/config/php/php.ini
@@ -1,0 +1,30 @@
+; General settings
+
+date.timezone = UTC
+xdebug.max_nesting_level=500
+short_open_tag = off
+memory_limit="512M"
+upload_max_filesize="20M"
+post_max_size="20M"
+
+
+; Error reporting optimized for production (http://www.phptherightway.com/#error_reporting)
+
+display_errors = Off
+display_startup_errors = Off
+error_reporting = E_ALL
+log_errors = On
+error_log = /var/log/php-app/error.log
+
+; Opcache settings (best on https://www.scalingphpbook.com/best-zend-opcache-settings-tuning-config/)
+
+opcache.revalidate_freq = 0
+opcache.max_accelerated_files = 7963
+opcache.memory_consumption = 96
+opcache.interned_strings_buffer = 16
+opcache.fast_shutdown = 1
+
+; Extensions
+
+#extension=imagick.so
+#extension = apcu.so

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,10 @@ io/*
 *.box
 .bashrc
 config.json
+www/config.json
 sphinx.conf
 .env
 .env.example
 phpMyAdmin/
+.idea/
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM php:fpm-alpine
+
+MAINTAINER development@oguzhanuysal.eu
+
+ENV CONF_MEMBERID=null
+ENV CONF_PASSHASH=null
+ENV CONF_ACCESSKEY=ChangeMeIAmNotSecure
+ENV DB_HOST=mariadb
+ENV DB_USER=dbuser
+ENV DB_PASS=pass
+ENV DB_NAME=exhen
+ENV CONF_TEMPDIR="./tmp"
+ENV CONF_ARCHDIR="./archive"
+ENV CONF_IMGDIR="./images"
+ENV CONF_SQLDSN="mysql:host=$DB_HOST;dbname=$DB_NAME"
+ENV CONF_SPHINXDSN="msql:host=sphinx;port=9306;dbname=exhen"
+ENV MEMCACHED_DEPS zlib-dev libmemcached-dev cyrus-sasl-dev
+ENV GIT_BRANCH=dev
+
+RUN apk add --no-cache --update libmemcached-libs zlib
+RUN set -xe \
+    && apk add --no-cache --update --virtual .phpize-deps $PHPIZE_DEPS \
+    && apk add --no-cache --update --virtual .memcached-deps $MEMCACHED_DEPS \
+    && pecl install memcached \
+    && echo "extension=memcached.so" > /usr/local/etc/php/conf.d/20_memcached.ini \
+    && rm -rf /usr/share/php7 \
+    && rm -rf /tmp/* \
+    && apk del .memcached-deps .phpize-deps
+
+RUN apk add --no-cache --update curl-dev jpeg-dev freetype-dev mysql-client \
+    && docker-php-ext-install -j$(nproc) mysqli \
+    && docker-php-ext-install -j$(nproc) pdo_mysql \
+    && docker-php-ext-install -j$(nproc) curl \
+    && docker-php-ext-install -j$(nproc) zip \
+    && docker-php-ext-install -j$(nproc) exif \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd
+
+# install jq for manilupating config from bash easily
+RUN apk add --update jq openssh-client\
+    && rm -rf /var/cache/apk/*
+
+COPY init.d.sh /usr/local/bin/
+COPY . /var/www
+WORKDIR /var/www
+
+RUN chmod +x /var/www/init.d.sh
+
+CMD ["init.d.sh"]

--- a/archives/.gitignore
+++ b/archives/.gitignore
@@ -1,0 +1,2 @@
+galleries/
+pages/

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,0 +1,10 @@
+version: '3.5'
+services:
+  web:
+    ports:
+      - "80:80"
+  app:
+    environment:
+      CONF_MEMBERID: null
+      CONF_PASSHASH: null
+      CONF_ACCESSKEY: ChangeMeIAmNotSecure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '3.5'
+services:
+  web:
+    image: nginx
+    links:
+      - app
+    volumes:
+      - ".:/var/www"
+      - "./.docker/config/nginx/vhost.conf:/etc/nginx/conf.d/default.conf:ro"
+      - "./images:/var/www/www/images"
+
+  app:
+    build: .
+    links:
+      - mariadb
+      - sphinx
+      - memcache
+    depends_on:
+      - mariadb
+    volumes:
+      - "./.docker/config/php/php.ini:/usr/local/etc/php/conf.d/030-custom.ini:ro"
+      - ".:/var/www"
+      - "./archives:/archive"
+      - "./images:/images"
+    environment:
+      TZ: UTC
+      CONF_MEMBERID: null
+      CONF_PASSHASH: null
+      CONF_ACCESSKEY: ChangeMeIAmNotSecure
+      CONF_TEMPDIR: "/tmp"
+      CONF_ARCHDIR: "/archive"
+      CONF_IMGDIR: "/images"
+      CONF_SPHINXDSN: "mysql:host=sphinx;port=9306;dbname=exhen"
+      DB_HOST: mariadb
+      DB_USER: appuser
+      DB_PASS: userPass
+      DB_NAME: exhen
+
+  mariadb:
+    image: mariadb
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    environment:
+      - "MYSQL_ROOT_PASSWORD=rootPass"
+      - "MYSQL_USER=appuser"
+      - "MYSQL_PASSWORD=userPass"
+      - "MYSQL_DATABASE=exhen"
+    volumes:
+      - "./db.sql:/docker-entrypoint-initdb.d/db.sql"
+
+  sphinx:
+    image: stefobark/sphinxdocker
+    links:
+      - mariadb
+    depends_on:
+      - mariadb
+    volumes:
+      - "./.docker/config/sphinx/sphinx.conf:/etc/sphinxsearch/sphinx.conf"
+    command: >
+      bash -c "curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > $HOME/wait-for-it.sh
+      && chmod +x $HOME/wait-for-it.sh
+      && $HOME/wait-for-it.sh --timeout=30 mariadb:3306
+      && mkdir -p /var/lib/sphinxsearch/data/exhen/
+      && mkdir -p /etc/sphinxsearch/log/
+      && (crontab -l ; echo \"*/10 * * * * indexer -c /etc/sphinxsearch/sphinx.conf --all --rotate > /proc/1/fd/1 2>/proc/1/fd/2\") | sort - | uniq - | crontab -
+      && apt-get install -y cron && cron
+      && indexer -c /etc/sphinxsearch/sphinx.conf --all --rotate
+      && searchd -c /etc/sphinxsearch/sphinx.conf --nodetach --pidfile"
+    expose:
+      - 9306
+
+  memcache:
+    image: memcached:alpine

--- a/docker-entrypoint-init.d/10-config.sh
+++ b/docker-entrypoint-init.d/10-config.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+if [ -f "config.json.linux" ]; then
+echo "Updating config.json"
+
+jq '.base.cookie.ipb_member_id=env.CONF_MEMBERID | .base.cookie.ipb_pass_hash=env.CONF_PASSHASH | .base.cookie.ipb_accesskey=env.CONF_ACCESSKEY | .base.tempDir=env.CONF_TEMPDIR | .base.archiveDir=env.CONF_ARCHDIR | .base.imagesDir=env.CONF_IMGDIR | .default.db.dsn=env.CONF_SQLDSN | .default.db.user=env.DB_USER | .default.db.pass=env.DB_PASS | .default.sphinxql.dsn=env.CONF_SPHINXDSN | .default.memcache.host="memcache"' config.json.linux > config.json
+cp config.json.linux www/config.json
+echo "Updated config"
+fi

--- a/docker-entrypoint-init.d/11-cron.sh
+++ b/docker-entrypoint-init.d/11-cron.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+if [ ! -f "/etc/periodic/15min/archive.sh" ]; then
+  cp /var/www/.docker/config/app/cron/15min/archive.sh /etc/periodic/15min/archive.sh
+  chmod +x /etc/periodic/15min/archive.sh
+  (crontab -l ; echo "*/10 * * * * /etc/periodic/15min/archive.sh > /proc/1/fd/1 2>/proc/1/fd/2") | sort - | uniq - | crontab -
+fi
+
+if [ ! -f "/etc/periodic/hourly/audit.sh" ]; then
+  cp /var/www/.docker/config/app/cron/hourly/audit.sh /etc/periodic/hourly/audit.sh
+  chmod +x /etc/periodic/hourly/audit.sh
+  (crontab -l ; echo "0 4 * * * /etc/periodic/hourly/audit.sh > /proc/1/fd/1 2>/proc/1/fd/2") | sort - | uniq - | crontab -
+fi
+
+if [ ! -f "/etc/periodic/hourly/thumbnails.sh" ]; then
+  cp /var/www/.docker/config/app/cron/hourly/thumbnails.sh /etc/periodic/hourly/thumbnails.sh
+  chmod +x /etc/periodic/hourly/thumbnails.sh
+  (crontab -l ; echo "0 5 * * * /etc/periodic/hourly/thumbnails.sh > /proc/1/fd/1 2>/proc/1/fd/2") | sort - | uniq - | crontab -
+fi
+
+
+crond

--- a/init.d.sh
+++ b/init.d.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+echo
+for f in docker-entrypoint-init.d/*; do
+    case "$f" in
+        *.sh)
+            # https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+            # https://github.com/docker-library/postgres/pull/452
+            if [ -x "$f" ]; then
+                echo "$0: running $f"
+                "$f"
+            else
+                echo "$0: sourcing $f"
+                . "$f"
+            fi
+            ;;
+        *)        echo "$0: ignoring $f" ;;
+    esac
+    echo
+done
+
+echo
+echo 'init process complete; ready for start up.'
+echo
+
+exec php-fpm

--- a/setup/Docker-setup.md
+++ b/setup/Docker-setup.md
@@ -1,0 +1,70 @@
+Docker Setup
+---
+
+###
+* Docker
+* Docker-compose
+* e-hentai account with ExHentai access
+* GP to download galleries
+
+Docker is generally the easiest way to get a compatible environment started as it contains all the required packages and configurations to get started.
+
+#### Getting started
+The easiest way to get a local (dev/test) environment up and running is by copying the `docker-compose.override.yml` to `docker-compose.override.yml`.
+This file will override the default values for configuration.
+
+After copying the override YAML, make sure to replace the `environment` parameters under the `app` section.
+
+* The `CONF_ACCESSKEY` option is a password used for deleting and adding galleries.
+* The `CONF_MEMBERID` and `CONF_PASSHASH` should be changed to match your ExHentai cookie.
+* The `db` block should stay as it is in most cases, with the exception of `pass`, which you should input whatever password you used for the MySQL setup step.
+* On first run add `INIT_DB: 1` to the `environment:` list for `web`. This will run the sql script to create the database
+* SphinxQL and memcache should stay as-is.
+
+Run: `docker-compose up` 
+Use `-d` flag to detach console and continue running in the background. Note, you will not get the log output by default if you run in detached mode. You'll have to use `docker logs` to check logs in that case, the instructions for that are out of scope for this guide.
+
+Visit `http://localhost` to see the webpage.
+
+#### Adding galleries
+
+Adding galleries is done via a userscript. Open the provided `userscript.js` file in a text editor and change the two values at the top of the code. The `baseUrl` in this example would be http://exhen.localhost and `key` would be the `accessKey` value in the config.json file.
+
+Once edited, add to your browser via Greasemonkey/Tampermonkey.
+
+The script will add a "Send to archive" link to the search results page (in thumbnails view) and on the gallery detail page. Clicking it will send it to the archive to be marked for download. Galleries added to the database will be marked in green on the search results page.
+
+After you have added a few galleries, you can now run the `Archive` task that will download them.
+
+    cd /var/www/vhosts/exhen
+    php TaskRunner.php Archive
+
+The task should download the galleries and reindex Sphinx.
+
+Once completed, reload http://exhen.localhost and you should see your galleries appear!
+
+#### Cron
+
+For ideal automation, tasks should be setup in the crontab of your system. Below is an example I use.
+
+    */10 * * * * cd /var/www/vhosts/exhen/ && php TaskRunner.php Archive >> log.txt 2>&1
+    0 4 * * * cd /var/www/vhosts/exhen/ && php TaskRunner.php Thumbnails >> log.txt 2>&1
+    0 5 * * * cd /var/www/vhosts/exhen/ && php TaskRunner.php Audit >> log.txt 2>&1
+
+There are 3 main tasks in use.
+
+* **Archive** - downloads pending galleries in the database;
+* **Audit** - updates meta data for added galleries. Will typically update each gallery periodically for new tags, or add newer versions of that gallery to the database.
+* **Thumbnails** - generates thumbs for galleries instead of doing it on-the-fly on the frontend.
+
+#### Extras
+
+If you find the search results are out of sync with the database, you may need to connect to the sphinx container and reindex Sphinx:
+
+    docker-compose run --rm sphinx "sudo -u sphinxsearch indexer --rotate --all"
+
+##### Feeds
+
+Feeds are ways of adding galleries to the database automatically through search terms. The Archive task will run through all feeds in the database, adding new galleries, and optionally downloading these galleries. Support for managing these in a friendly way does not exist.
+
+If you wish to play around with feeds, get a MySQL database admin tool (MySQL Workbench) and take a look at the feeds table. Create a new row with the `term` matching the search term you want (i.e "comic x-ero"), then `download` should be 1 or 0, depending on if you want the archiver to also download the gallery zips.


### PR DESCRIPTION
I've migrated all my servers (and roles) on my homelab to docker and thus been porting all servers to be able to run on docker.

This PR adds docker as an additional environment.
Using docker-compose only requires one copy action and changes to the docker-compose.override.yml file to have a local running instance