### PR TITLE
php notices

### DIFF
--- a/classes/ApiHandler.php
+++ b/classes/ApiHandler.php
@@ -487,7 +487,7 @@ class ApiHandler
     {
         $body = json_encode($resp);
 
-        ob_end_clean();
+        @ob_end_clean();
 
         if (function_exists('ob_gzhandler')) {
             ob_start('ob_gzhandler');

--- a/lib/PHPImageWorkshop/ImageWorkshop.php
+++ b/lib/PHPImageWorkshop/ImageWorkshop.php
@@ -73,7 +73,7 @@ class ImageWorkshop
         switch ($mimeContentType) {
             case 'jpeg':
                 $image = imageCreateFromJPEG($path);
-                if (false === ($exif = @read_exif_data($path))) {
+                if (false === ($exif = @\exif_read_data($path))) {
                     $exif = array();
                 }
             break;


### PR DESCRIPTION
Mute ob_clean_end because it complains about an empty/nonstarted buffer.
Replace read_exif_data with exif_read_data because the former is deprecated, removed in php7 and already aliases the latter one